### PR TITLE
Make configuration updates thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Verikloak::Pundit.configure do |c|
   #   :default_resource => realm roles + default client roles (recommended)
   #   :all_resources    => realm roles + roles from all clients in resource_access
   c.permission_role_scope = :default_resource
+
+  # Expose `verikloak_claims` to views via helper_method (Rails only)
+  c.expose_helper_method = true
 end
 ```
 

--- a/lib/verikloak/pundit.rb
+++ b/lib/verikloak/pundit.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # Verikloak::Pundit provides Pundit integration over Keycloak claims.
-require 'thread'
 require_relative 'pundit/version'
 require_relative 'pundit/configuration'
 require_relative 'pundit/role_mapper'
@@ -22,7 +21,7 @@ module Verikloak
       def configure
         new_config = nil
         config_mutex.synchronize do
-          current = (@config&.dup) || Configuration.new
+          current = @config&.dup || Configuration.new
           yield current if block_given?
           new_config = current.finalize!
           @config = new_config

--- a/lib/verikloak/pundit.rb
+++ b/lib/verikloak/pundit.rb
@@ -41,6 +41,9 @@ module Verikloak
 
       private
 
+      # Mutex protecting configuration reads/writes to maintain thread safety.
+      #
+      # @return [Mutex]
       def config_mutex
         @config_mutex ||= Mutex.new
       end

--- a/lib/verikloak/pundit/configuration.rb
+++ b/lib/verikloak/pundit/configuration.rb
@@ -16,10 +16,12 @@ module Verikloak
     #   @return [Array<String,Proc>] path inside JWT claims to reach resource roles
     # @!attribute permission_role_scope
     #   @return [Symbol] :default_resource or :all_resources for permission mapping scope
+    # @!attribute expose_helper_method
+    #   @return [Boolean] whether to register `verikloak_claims` as a Rails helper method
     class Configuration
       attr_accessor :resource_client, :role_map, :env_claims_key,
                     :realm_roles_path, :resource_roles_path,
-                    :permission_role_scope
+                    :permission_role_scope, :expose_helper_method
 
       def initialize(copy_from = nil)
         if copy_from
@@ -52,6 +54,7 @@ module Verikloak
         @role_map = dup_hash(@role_map).freeze
         @realm_roles_path = dup_array(@realm_roles_path).freeze
         @resource_roles_path = dup_array(@resource_roles_path).freeze
+        @expose_helper_method = !!@expose_helper_method
         freeze
       end
 
@@ -67,6 +70,7 @@ module Verikloak
         # rubocop:enable Style/SymbolProc
         # :default_resource (realm + default client), :all_resources (realm + all clients)
         @permission_role_scope = :default_resource
+        @expose_helper_method = true
       end
 
       def initialize_from(other)
@@ -76,6 +80,7 @@ module Verikloak
         @realm_roles_path = dup_array(other.realm_roles_path)
         @resource_roles_path = dup_array(other.resource_roles_path)
         @permission_role_scope = other.permission_role_scope
+        @expose_helper_method = other.expose_helper_method
       end
 
       def freeze_string(value)

--- a/lib/verikloak/pundit/configuration.rb
+++ b/lib/verikloak/pundit/configuration.rb
@@ -38,10 +38,16 @@ module Verikloak
       # Create a deep-ish copy that can be safely mutated without affecting the
       # source configuration. `dup` is overridden so the object returned from
       # `Verikloak::Pundit.config.dup` behaves as expected.
+      #
+      # @return [Configuration]
       def dup
         self.class.new(self)
       end
 
+      # Duplicate the configuration via Ruby's `dup`, ensuring the new instance
+      # receives freshly-copied nested state.
+      #
+      # @param other [Configuration]
       def initialize_copy(other)
         super
         initialize_from(other)

--- a/lib/verikloak/pundit/configuration.rb
+++ b/lib/verikloak/pundit/configuration.rb
@@ -23,6 +23,10 @@ module Verikloak
                     :realm_roles_path, :resource_roles_path,
                     :permission_role_scope, :expose_helper_method
 
+      # Build a new configuration, optionally copying values from another
+      # configuration so callers can mutate a safe duplicate.
+      #
+      # @param copy_from [Configuration, nil]
       def initialize(copy_from = nil)
         if copy_from
           initialize_from(copy_from)
@@ -60,6 +64,7 @@ module Verikloak
 
       private
 
+      # Populate default values that mirror the gem's out-of-the-box behavior.
       def initialize_defaults
         @resource_client   = 'rails-api'
         @role_map          = {} # e.g., { admin: :manage_all }
@@ -73,6 +78,10 @@ module Verikloak
         @expose_helper_method = true
       end
 
+      # Copy configuration fields from another instance, duplicating mutable
+      # structures so future writes do not leak across instances.
+      #
+      # @param other [Configuration]
       def initialize_from(other)
         @resource_client = dup_string(other.resource_client)
         @role_map = dup_hash(other.role_map)
@@ -83,12 +92,21 @@ module Verikloak
         @expose_helper_method = other.expose_helper_method
       end
 
+      # Duplicate and freeze a string value, returning `nil` when appropriate.
+      #
+      # @param value [String, nil]
+      # @return [String, nil]
       def freeze_string(value)
         return nil if value.nil?
 
         dup_string(value).freeze
       end
 
+      # Recursively duplicate a hash, cloning nested structures so the copy can
+      # be mutated safely.
+      #
+      # @param value [Hash, nil]
+      # @return [Hash, nil]
       def dup_hash(value)
         return nil if value.nil?
 
@@ -109,12 +127,20 @@ module Verikloak
         copy
       end
 
+      # Duplicate a string guardingly, returning `nil` when no value is present.
+      #
+      # @param value [String, nil]
+      # @return [String, nil]
       def dup_string(value)
         return nil if value.nil?
 
         value.dup
       end
 
+      # Recursively duplicate an array while copying nested structures.
+      #
+      # @param value [Array, nil]
+      # @return [Array, nil]
       def dup_array(value)
         return nil if value.nil?
 
@@ -135,6 +161,10 @@ module Verikloak
         end
       end
 
+      # Check whether a value can be safely duplicated using `dup`.
+      #
+      # @param value [Object]
+      # @return [Boolean]
       def duplicable?(value)
         case value
         when nil, true, false, Symbol, Numeric, Proc

--- a/lib/verikloak/pundit/controller.rb
+++ b/lib/verikloak/pundit/controller.rb
@@ -7,7 +7,10 @@ module Verikloak
       # Hook used by Rails to include helper methods in views when available.
       # @param base [Class]
       def self.included(base)
-        base.helper_method :verikloak_claims if base.respond_to?(:helper_method)
+        return unless base.respond_to?(:helper_method)
+
+        config = Verikloak::Pundit.config
+        base.helper_method :verikloak_claims if config.expose_helper_method
       end
 
       # Pundit hook returning the UserContext built from Rack env claims.

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Verikloak::Pundit::Configuration do
     expect(cfg.realm_roles_path).to eq(%w[realm_access roles])
     expect(cfg.resource_roles_path).to be_a(Array)
     expect(cfg.permission_role_scope).to eq(:default_resource)
+    expect(cfg.expose_helper_method).to be(true)
   end
 
   it "is configurable via Verikloak::Pundit.configure" do
@@ -19,20 +20,24 @@ RSpec.describe Verikloak::Pundit::Configuration do
         c.resource_client = "api"
         c.role_map = { admin: :all }
         c.permission_role_scope = :all_resources
+        c.expose_helper_method = false
       end
       expect(result).to be_a(described_class)
       expect(result).to be_frozen
       expect(result.resource_client).to be_frozen
       expect(result.role_map).to be_frozen
       expect(result.env_claims_key).to be_frozen
+      expect(result.expose_helper_method).to be(false)
       expect(Verikloak::Pundit.config.resource_client).to eq("api")
       expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all })
       expect(Verikloak::Pundit.config.permission_role_scope).to eq(:all_resources)
+      expect(Verikloak::Pundit.config.expose_helper_method).to be(false)
     ensure
       Verikloak::Pundit.configure do |c|
         c.resource_client = "rails-api"
         c.role_map = {}
         c.permission_role_scope = :default_resource
+        c.expose_helper_method = true
       end
     end
   end
@@ -55,6 +60,7 @@ RSpec.describe Verikloak::Pundit::Configuration do
       Verikloak::Pundit.configure do |c|
         c.resource_client = "rails-api"
         c.role_map = {}
+        c.expose_helper_method = true
       end
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe Verikloak::Pundit::Configuration do
         c.permission_role_scope = :all_resources
       end
       expect(result).to be_a(described_class)
+      expect(result).to be_frozen
+      expect(result.resource_client).to be_frozen
+      expect(result.role_map).to be_frozen
+      expect(result.env_claims_key).to be_frozen
       expect(Verikloak::Pundit.config.resource_client).to eq("api")
       expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all })
       expect(Verikloak::Pundit.config.permission_role_scope).to eq(:all_resources)
@@ -29,6 +33,28 @@ RSpec.describe Verikloak::Pundit::Configuration do
         c.resource_client = "rails-api"
         c.role_map = {}
         c.permission_role_scope = :default_resource
+      end
+    end
+  end
+
+  it "provides unfrozen copies when reconfiguring" do
+    begin
+      Verikloak::Pundit.configure do |c|
+        c.resource_client = "api"
+        c.role_map = { admin: :all }
+      end
+
+      Verikloak::Pundit.configure do |c|
+        expect(c).not_to be_frozen
+        expect(c.role_map).not_to be_frozen
+        c.role_map[:reader] = :read
+      end
+
+      expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all, reader: :read })
+    ensure
+      Verikloak::Pundit.configure do |c|
+        c.resource_client = "rails-api"
+        c.role_map = {}
       end
     end
   end


### PR DESCRIPTION
## Summary
- guard configuration mutation with a mutex and publish frozen copies, including string fields
- teach Configuration how to duplicate itself safely and freeze nested data
- extend configuration specs to cover immutability, including string attributes, and reconfiguration behavior