### PR TITLE
Add permission client whitelist and improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0] - 2025-09-21
+
+### Added
+- Allow `permission_role_scope = :all_resources` to respect the new
+  `permission_resource_clients` whitelist so only approved clients contribute
+  to permission checks.
+- Document verikloak-bff and verikloak-audience integration patterns,
+  including `env_claims_key` examples and role naming guidance.
+
+### Changed
+- `UserContext` now snapshots the configuration at initialization to keep
+  behavior consistent even if `Verikloak::Pundit.configure` runs mid-request.
+- Bump the minimum `verikloak` runtime dependency to `>= 0.1.5` to pick up
+  client whitelist support.
+
 ## [0.1.1] - 2025-09-20
 
 ### Added

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -26,6 +26,10 @@ This document summarizes error handling expectations, fallback behaviors, and op
 
 ## Operational Security Notes
 - Enabling `permission_role_scope = :all_resources` means every client listed in `resource_access` contributes roles to the permission checks. Review the upstream assignments before enabling it so that you do not unintentionally broaden authorization scope.
+- When you enable `:all_resources`, set `permission_resource_clients` to the explicit
+  list of clients that should influence permissions. Leaving it `nil` restores the
+  legacy "trust every client" behavior, which may not be appropriate when tokens are
+  shared across services (for example, via verikloak-bff).
 - Keeping `expose_helper_method` set to `true` exposes `verikloak_claims` directly to views. If the claims carry personal or sensitive information, prefer disabling it (`false`) and limit the data passed to templates.
 
 ## Logging and Debugging Tips

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    verikloak-pundit (0.1.1)
+    verikloak-pundit (0.2.0)
       pundit (~> 2.3)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.1.2, < 0.2)
+      verikloak (>= 0.1.5, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -40,6 +40,8 @@ GEM
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.2)
+      faraday (~> 2.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.13.2)
@@ -115,8 +117,9 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
     uri (1.0.3)
-    verikloak (0.1.3)
+    verikloak (0.1.5)
       faraday (>= 2.0, < 3.0)
+      faraday-retry (>= 2.0, < 3.0)
       json (~> 2.6)
       jwt (>= 2.7, < 4.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-24
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/integration/check.rb
+++ b/integration/check.rb
@@ -53,7 +53,9 @@ Verikloak::Pundit.configure do |config|
   config.permission_role_scope = :all_resources
 end
 user_all_resources = Verikloak::Pundit::UserContext.new(claims)
-raise 'UserContext failed to include roles from all resources' unless user_all_resources.has_permission?(:publish_insights)
+unless user_all_resources.has_permission?(:publish_insights)
+  raise 'UserContext failed to include roles from all resources'
+end
 
 # Helper exposure should respect configuration flag
 klass = Class.new do

--- a/integration/check.rb
+++ b/integration/check.rb
@@ -52,7 +52,8 @@ raise 'UserContext.from_env lost permissions' unless user_from_env.has_permissio
 Verikloak::Pundit.configure do |config|
   config.permission_role_scope = :all_resources
 end
-raise 'UserContext failed to include roles from all resources' unless user.has_permission?(:publish_insights)
+user_all_resources = Verikloak::Pundit::UserContext.new(claims)
+raise 'UserContext failed to include roles from all resources' unless user_all_resources.has_permission?(:publish_insights)
 
 # Helper exposure should respect configuration flag
 klass = Class.new do

--- a/lib/generators/verikloak/pundit/install/install_generator.rb
+++ b/lib/generators/verikloak/pundit/install/install_generator.rb
@@ -11,7 +11,6 @@ module Verikloak
         desc 'Creates Verikloak Pundit initializer and a base ApplicationPolicy (optional).'
 
         # Skip creating application_policy.rb
-        # @return [Boolean]
         class_option :skip_policy, type: :boolean, default: false, desc: 'Do not create application_policy.rb'
 
         # Create the initializer file under config/initializers.

--- a/lib/verikloak/pundit/version.rb
+++ b/lib/verikloak/pundit/version.rb
@@ -5,6 +5,6 @@ module Verikloak
     # Gem version for verikloak-pundit.
     #
     # @return [String]
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/verikloak-pundit.gemspec
+++ b/verikloak-pundit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'pundit', '~> 2.3'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.1.2', '< 0.2'
+  spec.add_dependency 'verikloak', '>= 0.1.5', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
## Summary
- add an optional `permission_resource_clients` allowlist for the `:all_resources` scope
- snapshot the runtime configuration inside `UserContext` to keep permission checks consistent within a request
- document cross-gem usage guidance and updated operational notes for verikloak-bff and verikloak-audience