### PR TITLE
Refactor delegations and document reset helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration duplication derives from a unified `deep_dup`, ensuring hash keys are copied and nested structures remain isolated.
 - README documents the new delegations module, configuration reset helper, and deprecation guidance.
 
-### Deprecated
-- `Verikloak::Pundit::Helpers` and `Verikloak::Pundit::Policy`; include `Verikloak::Pundit::Delegations` directly ahead of their removal in v1.0.0.
-
 ## [0.2.0] - 2025-09-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2025-09-22
+
+### Added
+- `Verikloak::Pundit.reset!` helper to restore default configuration, easing test teardown.
+- `Verikloak::Pundit::Delegations` shared module consolidating role and permission helper methods.
+- `Verikloak::Pundit::ClaimUtils` for consistent claim normalization across entry points.
+
+### Changed
+- `UserContext` memoizes role lookups and caches mapped permissions to reduce repeated work inside policies.
+- `UserContext` now normalizes inputs via `ClaimUtils` and supports symbolized permission comparison for mixed role map values.
+- Configuration duplication derives from a unified `deep_dup`, ensuring hash keys are copied and nested structures remain isolated.
+- README documents the new delegations module, configuration reset helper, and deprecation guidance.
+
+### Deprecated
+- `Verikloak::Pundit::Helpers` and `Verikloak::Pundit::Policy`; include `Verikloak::Pundit::Delegations` directly ahead of their removal in v1.0.0.
+
 ## [0.2.0] - 2025-09-21
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-pundit (0.2.0)
+    verikloak-pundit (0.2.1)
       pundit (~> 2.3)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.1.5, < 1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     verikloak-pundit (0.2.1)
       pundit (~> 2.3)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.1.5, < 1.0.0)
+      verikloak (>= 0.2.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pundit integration for the **Verikloak** family. This gem maps **Keycloak roles*
 ## Features
 
 - **UserContext**: lightweight wrapper around JWT claims
-- **Helpers**: `has_role?`, `in_group?`, `resource_role?(client, role)`
+- **Delegations**: `has_role?`, `in_group?`, `resource_role?(client, role)` helpers for controllers and policies
 - **RoleMapper**: optional map from Keycloak roles → domain permissions
 - **Controller integration**: `pundit_user` provider for Rails controllers
 - **Generator**: `rails g verikloak:pundit:install` creates initializer + policy template (with `has_permission?` support for realm roles plus the configured resource scope)
@@ -138,6 +138,14 @@ To run the test suite locally:
 ```bash
 docker compose run --rm dev rspec
 docker compose run --rm dev rubocop -a
+```
+
+When writing specs, call `Verikloak::Pundit.reset!` in your test teardown to ensure configuration changes do not leak between examples:
+
+```ruby
+RSpec.configure do |config|
+  config.after { Verikloak::Pundit.reset! }
+end
 ```
 
 An additional integration check exercises the gem together with the latest `verikloak` and `verikloak-rails` releases. This runs in CI automatically, and you can execute it locally with:

--- a/integration/check.rb
+++ b/integration/check.rb
@@ -88,11 +88,6 @@ end
 raise 'Controller exposed helper despite being disabled' if klass.helper_method_calls
 
 # Restore defaults after integration checks
-Verikloak::Pundit.configure do |config|
-  config.resource_client = 'rails-api'
-  config.role_map = {}
-  config.permission_role_scope = :default_resource
-  config.expose_helper_method = true
-end
+Verikloak::Pundit.reset!
 
 puts 'verikloak + verikloak-rails integration check passed'

--- a/lib/verikloak/pundit.rb
+++ b/lib/verikloak/pundit.rb
@@ -4,6 +4,8 @@
 require_relative 'pundit/version'
 require_relative 'pundit/configuration'
 require_relative 'pundit/role_mapper'
+require_relative 'pundit/delegations'
+require_relative 'pundit/claim_utils'
 require_relative 'pundit/user_context'
 require_relative 'pundit/helpers'
 require_relative 'pundit/controller'
@@ -35,6 +37,15 @@ module Verikloak
       def config
         config_mutex.synchronize do
           @config ||= Configuration.new.finalize!
+        end
+      end
+
+      # Reset configuration to defaults. Useful for test suites.
+      #
+      # @return [void]
+      def reset!
+        config_mutex.synchronize do
+          @config = nil
         end
       end
 

--- a/lib/verikloak/pundit/claim_utils.rb
+++ b/lib/verikloak/pundit/claim_utils.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Verikloak
+  module Pundit
+    # Helpers for coercing incoming claims payloads into safe Hashes.
+    module ClaimUtils
+      module_function
+
+      # Normalize incoming claims to a Hash to guard against odd payload types.
+      #
+      # @param claims [Object]
+      # @return [Hash]
+      def normalize(claims)
+        return {} if claims.nil?
+        return claims if claims.is_a?(Hash)
+
+        if claims.respond_to?(:to_hash)
+          coerced = claims.to_hash
+          return coerced if coerced.is_a?(Hash)
+        end
+
+        {}
+      rescue StandardError
+        {}
+      end
+    end
+  end
+end

--- a/lib/verikloak/pundit/configuration.rb
+++ b/lib/verikloak/pundit/configuration.rb
@@ -124,8 +124,8 @@ module Verikloak
         when nil
           nil
         when Hash
-          value.transform_values do |element|
-            deep_dup(element)
+          value.each_with_object({}) do |(key, element), copy|
+            copy[deep_dup(key)] = deep_dup(element)
           end
         when Array
           value.map { |element| deep_dup(element) }

--- a/lib/verikloak/pundit/configuration.rb
+++ b/lib/verikloak/pundit/configuration.rb
@@ -115,29 +115,33 @@ module Verikloak
         dup_string(value).freeze
       end
 
-      # Recursively duplicate a hash, cloning nested structures so the copy can
-      # be mutated safely.
+      # Deep duplicate any object, handling nested structures recursively.
+      #
+      # @param value [Object] The value to duplicate
+      # @return [Object] A deep copy of the value
+      def deep_dup(value)
+        case value
+        when nil
+          nil
+        when Hash
+          value.transform_values do |element|
+            deep_dup(element)
+          end
+        when Array
+          value.map { |element| deep_dup(element) }
+        when String
+          value.dup
+        else
+          duplicable?(value) ? value.dup : value
+        end
+      end
+
+      # Duplicate a hash using deep duplication.
       #
       # @param value [Hash, nil]
       # @return [Hash, nil]
       def dup_hash(value)
-        return nil if value.nil?
-
-        copy = value.dup
-        copy.each do |key, element|
-          copy[key] =
-            case element
-            when Hash
-              dup_hash(element)
-            when Array
-              dup_array(element)
-            when String
-              dup_string(element)
-            else
-              duplicable?(element) ? element.dup : element
-            end
-        end
-        copy
+        deep_dup(value)
       end
 
       # Duplicate a string guardingly, returning `nil` when no value is present.
@@ -145,33 +149,15 @@ module Verikloak
       # @param value [String, nil]
       # @return [String, nil]
       def dup_string(value)
-        return nil if value.nil?
-
-        value.dup
+        deep_dup(value)
       end
 
-      # Recursively duplicate an array while copying nested structures.
+      # Duplicate an array using deep duplication.
       #
       # @param value [Array, nil]
       # @return [Array, nil]
       def dup_array(value)
-        return nil if value.nil?
-
-        copy = value.dup
-        return copy unless copy.respond_to?(:map)
-
-        copy.map do |element|
-          case element
-          when Hash
-            dup_hash(element)
-          when Array
-            dup_array(element)
-          when String
-            dup_string(element)
-          else
-            duplicable?(element) ? element.dup : element
-          end
-        end
+        deep_dup(value)
       end
 
       # Check whether a value can be safely duplicated using `dup`.

--- a/lib/verikloak/pundit/delegations.rb
+++ b/lib/verikloak/pundit/delegations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Verikloak
+  module Pundit
+    # Shared role/permission delegations to expose consistent helpers.
+    module Delegations
+      # Check whether the user has a realm role.
+      # @param role [String, Symbol]
+      # @return [Boolean]
+      def has_role?(role) = user.has_role?(role) # rubocop:disable Naming/PredicatePrefix
+
+      # Check whether the user belongs to a group (alias to role).
+      # @param group [String, Symbol]
+      # @return [Boolean]
+      def in_group?(group) = user.in_group?(group)
+
+      # Check whether the user has a role for a specific resource client.
+      # @param client [String, Symbol]
+      # @param role [String, Symbol]
+      # @return [Boolean]
+      def resource_role?(client, role) = user.resource_role?(client, role)
+
+      # Check whether the user has a mapped permission.
+      # @param perm [String, Symbol]
+      # @return [Boolean]
+      def has_permission?(perm) = user.has_permission?(perm) # rubocop:disable Naming/PredicatePrefix
+    end
+  end
+end

--- a/lib/verikloak/pundit/helpers.rb
+++ b/lib/verikloak/pundit/helpers.rb
@@ -3,27 +3,21 @@
 module Verikloak
   module Pundit
     # Helpers expose convenient delegations to the policy `user`.
+    #
+    # @deprecated Use {Delegations} directly instead. This module will be removed in v1.0.0.
     module Helpers
-      # Check whether the user has a realm role.
-      # @param role [String, Symbol]
-      # @return [Boolean]
-      def has_role?(role) = user.has_role?(role) # rubocop:disable Naming/PredicatePrefix
+      include Delegations
 
-      # Check whether the user belongs to a group (alias to role).
-      # @param group [String, Symbol]
-      # @return [Boolean]
-      def in_group?(group) = user.in_group?(group)
-
-      # Check whether the user has a role for a specific resource client.
-      # @param client [String, Symbol]
-      # @param role [String, Symbol]
-      # @return [Boolean]
-      def resource_role?(client, role) = user.resource_role?(client, role)
-
-      # Check whether the user has a mapped permission.
-      # @param perm [String, Symbol]
-      # @return [Boolean]
-      def has_permission?(perm) = user.has_permission?(perm) # rubocop:disable Naming/PredicatePrefix
+      # Warn consumers when the deprecated helper module is included.
+      #
+      # @param base [Module] module or class including this helper
+      # @return [void]
+      def self.included(base)
+        warn '[DEPRECATED] Verikloak::Pundit::Helpers is deprecated. ' \
+             'Include Verikloak::Pundit::Delegations directly instead. ' \
+             'This will be removed in v1.0.0.'
+        super
+      end
     end
   end
 end

--- a/lib/verikloak/pundit/policy.rb
+++ b/lib/verikloak/pundit/policy.rb
@@ -3,34 +3,25 @@
 module Verikloak
   module Pundit
     # Policy mixin to delegate common helpers to the `user` context.
+    #
+    # @deprecated Use {Delegations} directly instead. This module will be removed in v1.0.0.
     module Policy
+      # Warn consumers when the deprecated policy mixin is included.
+      #
+      # @param base [Module] module or class including this policy mixin
+      # @return [void]
       def self.included(base)
+        warn '[DEPRECATED] Verikloak::Pundit::Policy is deprecated. ' \
+             'Include Verikloak::Pundit::Delegations directly instead. ' \
+             'This will be removed in v1.0.0.'
         base.extend(ClassMethods)
+        super
       end
 
       # Placeholder for future class-level helpers
       module ClassMethods; end
 
-      # Check whether the user has a realm role.
-      # @param role [String, Symbol]
-      # @return [Boolean]
-      def has_role?(role) = user.has_role?(role) # rubocop:disable Naming/PredicatePrefix
-
-      # Check whether the user belongs to a group (alias to role).
-      # @param group [String, Symbol]
-      # @return [Boolean]
-      def in_group?(group) = user.in_group?(group)
-
-      # Check whether the user has a role for a specific resource client.
-      # @param client [String, Symbol]
-      # @param role [String, Symbol]
-      # @return [Boolean]
-      def resource_role?(client, role) = user.resource_role?(client, role)
-
-      # Check whether the user has a mapped permission.
-      # @param perm [String, Symbol]
-      # @return [Boolean]
-      def has_permission?(perm) = user.has_permission?(perm) # rubocop:disable Naming/PredicatePrefix
+      include Delegations
     end
   end
 end

--- a/lib/verikloak/pundit/user_context.rb
+++ b/lib/verikloak/pundit/user_context.rb
@@ -101,7 +101,7 @@ module Verikloak
       # @return [UserContext]
       def self.from_env(env)
         config = Verikloak::Pundit.config
-        claims = env&.[](config.env_claims_key)
+        claims = env&.fetch(config.env_claims_key, nil)
         new(claims, config: config)
       end
 

--- a/lib/verikloak/pundit/user_context.rb
+++ b/lib/verikloak/pundit/user_context.rb
@@ -135,7 +135,7 @@ module Verikloak
         when :all_resources
           resource_roles_all_clients
         else
-          resource_roles(resource_client)
+          resource_roles
         end
       end
 

--- a/lib/verikloak/pundit/user_context.rb
+++ b/lib/verikloak/pundit/user_context.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
+require 'set'
+
 module Verikloak
   module Pundit
     # Lightweight wrapper around Keycloak claims for Pundit policies.
     class UserContext
+      # JWT claim keys used internally
+      CLAIM_SUB = 'sub'
+      CLAIM_EMAIL = 'email'
+      CLAIM_PREFERRED_USERNAME = 'preferred_username'
+      CLAIM_RESOURCE_ACCESS = 'resource_access'
+      CLAIM_ROLES = 'roles'
+
       attr_reader :claims, :resource_client, :config
 
       # Create a new user context from JWT claims.
@@ -13,27 +22,29 @@ module Verikloak
       # @param config [Verikloak::Pundit::Configuration] configuration snapshot to use
       def initialize(claims, resource_client: nil, config: nil)
         @config = config || Verikloak::Pundit.config
-        @claims = claims || {}
+        @claims = ClaimUtils.normalize(claims)
         @resource_client = (resource_client || @config.resource_client).to_s
       end
 
       # Subject identifier from claims.
       # @return [String, nil]
       def sub
-        claims['sub']
+        claims[CLAIM_SUB]
       end
 
       # Email or preferred username from claims.
       # @return [String, nil]
       def email
-        claims['email'] || claims['preferred_username']
+        claims[CLAIM_EMAIL] || claims[CLAIM_PREFERRED_USERNAME]
       end
 
       # Realm-level roles from claims based on configuration path.
       # @return [Array<String>]
       def realm_roles
-        path = resolve_path(config.realm_roles_path)
-        Array(claims.dig(*path))
+        @realm_roles ||= begin
+          path = resolve_path(config.realm_roles_path)
+          Array(claims.dig(*path)).map(&:to_s).uniq.freeze
+        end
       end
 
       # Resource-level roles for a given client from claims based on configuration path.
@@ -42,8 +53,10 @@ module Verikloak
       # @return [Array<String>]
       def resource_roles(client = resource_client)
         client = client.to_s
-        path = resolve_path(config.resource_roles_path, client: client)
-        Array(claims.dig(*path))
+        (@resource_roles_cache ||= {})[client] ||= begin
+          path = resolve_path(config.resource_roles_path, client: client)
+          Array(claims.dig(*path)).map(&:to_s).uniq.freeze
+        end
       end
 
       # Check whether the user has a realm role.
@@ -51,8 +64,7 @@ module Verikloak
       # @param role [String, Symbol]
       # @return [Boolean]
       def has_role?(role) # rubocop:disable Naming/PredicatePrefix
-        r = role.to_s
-        realm_roles.include?(r)
+        realm_roles.include?(role.to_s)
       end
 
       # Alias to has_role? to align with group-based naming.
@@ -69,9 +81,7 @@ module Verikloak
       # @param role [String, Symbol]
       # @return [Boolean]
       def resource_role?(client, role)
-        client = client.to_s
-        r = role.to_s
-        resource_roles(client).include?(r)
+        resource_roles(client).include?(role.to_s)
       end
 
       # Check whether the user has a mapped permission.
@@ -82,10 +92,7 @@ module Verikloak
       # @param perm [String, Symbol] permission to check
       # @return [Boolean]
       def has_permission?(perm) # rubocop:disable Naming/PredicatePrefix
-        pr = perm.to_sym
-        roles = realm_roles + resource_roles_scope
-        mapped = roles.map { |r| RoleMapper.map(r, config) }
-        mapped.map(&:to_sym).include?(pr)
+        permission_set.include?(normalize_to_symbol(perm))
       end
 
       # Build a user context from Rack env using configured claims key.
@@ -94,7 +101,7 @@ module Verikloak
       # @return [UserContext]
       def self.from_env(env)
         config = Verikloak::Pundit.config
-        claims = env[config.env_claims_key]
+        claims = env&.[](config.env_claims_key)
         new(claims, config: config)
       end
 
@@ -128,22 +135,25 @@ module Verikloak
         when :all_resources
           resource_roles_all_clients
         else
-          resource_roles
+          resource_roles(resource_client)
         end
       end
 
       # Collect resource roles from all clients under resource_access.
       # @return [Array<String>]
       def resource_roles_all_clients
-        access = claims['resource_access']
-        return [] unless access.is_a?(Hash)
+        @resource_roles_all_clients ||= begin
+          access = claims[CLAIM_RESOURCE_ACCESS]
+          if access.is_a?(Hash)
+            roles = access.each_with_object([]) do |(client_id, entry), acc|
+              next unless permission_client_allowed?(client_id)
 
-        # Bypass configured path lambda (which targets the default client)
-        # and gather roles from all clients explicitly.
-        access.each_with_object([]) do |(client_id, entry), roles|
-          next unless permission_client_allowed?(client_id)
-
-          roles.concat(Array(entry['roles']))
+              acc.concat(Array(entry[CLAIM_ROLES]))
+            end
+            roles.map(&:to_s).uniq.freeze
+          else
+            [].freeze
+          end
         end
       end
 
@@ -156,6 +166,52 @@ module Verikloak
         return true if whitelist.nil?
 
         whitelist.include?(client_id.to_s)
+      end
+
+      # Cached permission lookup set combining realm and configured resource scopes.
+      # @return [Set<Symbol>]
+      def permission_set
+        @permission_set ||= build_permission_set.freeze
+      end
+
+      # Build the permission set from roles and role mappings.
+      # @return [Set<Symbol>]
+      def build_permission_set
+        roles = realm_roles + resource_roles_scope
+        permissions = Set.new
+
+        roles.each do |role|
+          mapped_permission = RoleMapper.map(role, config)
+          symbol_permission = normalize_to_symbol(mapped_permission)
+          permissions << symbol_permission if symbol_permission
+        end
+
+        permissions
+      end
+
+      # Normalize a value to a symbol, handling various types safely.
+      # @param value [Object] The value to convert to a symbol
+      # @return [Symbol, nil] The symbol representation, or nil if not convertible
+      def normalize_to_symbol(value)
+        case value
+        when Symbol
+          value
+        when String
+          return nil if value.empty?
+
+          value.to_sym
+        else
+          if value.respond_to?(:to_sym)
+            value.to_sym
+          elsif value.respond_to?(:to_s)
+            text = value.to_s
+            return nil if text.empty?
+
+            text.to_sym
+          end
+        end
+      rescue StandardError
+        nil
       end
     end
   end

--- a/lib/verikloak/pundit/version.rb
+++ b/lib/verikloak/pundit/version.rb
@@ -5,6 +5,6 @@ module Verikloak
     # Gem version for verikloak-pundit.
     #
     # @return [String]
-    VERSION = '0.2.0'
+    VERSION = '0.2.1'
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -3,6 +3,10 @@
 require "spec_helper"
 
 RSpec.describe Verikloak::Pundit::Configuration do
+  after do
+    Verikloak::Pundit.reset!
+  end
+
   it "has sensible defaults" do
     cfg = described_class.new
     expect(cfg.resource_client).to eq("rails-api")
@@ -16,86 +20,58 @@ RSpec.describe Verikloak::Pundit::Configuration do
   end
 
   it "is configurable via Verikloak::Pundit.configure" do
-    begin
-      result = Verikloak::Pundit.configure do |c|
-        c.resource_client = "api"
-        c.role_map = { admin: :all }
-        c.permission_role_scope = :all_resources
-        c.permission_resource_clients = [:api, "rails-api"]
-        c.expose_helper_method = false
-      end
-      expect(result).to be_a(described_class)
-      expect(result).to be_frozen
-      expect(result.resource_client).to be_frozen
-      expect(result.role_map).to be_frozen
-      expect(result.env_claims_key).to be_frozen
-      expect(result.permission_resource_clients).to eq(%w[api rails-api])
-      expect(result.permission_resource_clients).to be_frozen
-      expect(result.expose_helper_method).to be(false)
-      expect(Verikloak::Pundit.config.resource_client).to eq("api")
-      expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all })
-      expect(Verikloak::Pundit.config.permission_role_scope).to eq(:all_resources)
-      expect(Verikloak::Pundit.config.permission_resource_clients).to eq(%w[api rails-api])
-      expect(Verikloak::Pundit.config.expose_helper_method).to be(false)
-    ensure
-      Verikloak::Pundit.configure do |c|
-        c.resource_client = "rails-api"
-        c.role_map = {}
-        c.permission_role_scope = :default_resource
-        c.permission_resource_clients = nil
-        c.expose_helper_method = true
-      end
+    result = Verikloak::Pundit.configure do |c|
+      c.resource_client = "api"
+      c.role_map = { admin: :all }
+      c.permission_role_scope = :all_resources
+      c.permission_resource_clients = [:api, "rails-api"]
+      c.expose_helper_method = false
     end
+    expect(result).to be_a(described_class)
+    expect(result).to be_frozen
+    expect(result.resource_client).to be_frozen
+    expect(result.role_map).to be_frozen
+    expect(result.env_claims_key).to be_frozen
+    expect(result.permission_resource_clients).to eq(%w[api rails-api])
+    expect(result.permission_resource_clients).to be_frozen
+    expect(result.expose_helper_method).to be(false)
+    expect(Verikloak::Pundit.config.resource_client).to eq("api")
+    expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all })
+    expect(Verikloak::Pundit.config.permission_role_scope).to eq(:all_resources)
+    expect(Verikloak::Pundit.config.permission_resource_clients).to eq(%w[api rails-api])
+    expect(Verikloak::Pundit.config.expose_helper_method).to be(false)
   end
 
   it "provides unfrozen copies when reconfiguring" do
-    begin
-      Verikloak::Pundit.configure do |c|
-        c.resource_client = "api"
-        c.role_map = { admin: :all }
-      end
-
-      Verikloak::Pundit.configure do |c|
-        expect(c).not_to be_frozen
-        expect(c.role_map).not_to be_frozen
-        c.role_map[:reader] = :read
-      end
-
-      expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all, reader: :read })
-    ensure
-      Verikloak::Pundit.configure do |c|
-        c.resource_client = "rails-api"
-        c.role_map = {}
-        c.permission_resource_clients = nil
-        c.expose_helper_method = true
-      end
+    Verikloak::Pundit.configure do |c|
+      c.resource_client = "api"
+      c.role_map = { admin: :all }
     end
+
+    Verikloak::Pundit.configure do |c|
+      expect(c).not_to be_frozen
+      expect(c.role_map).not_to be_frozen
+      c.role_map[:reader] = :read
+    end
+
+    expect(Verikloak::Pundit.config.role_map).to eq({ admin: :all, reader: :read })
   end
 
   it "does not share nested configuration structures across publishes" do
-    begin
-      Verikloak::Pundit.configure do |c|
-        c.role_map = { admin: [:manage_all] }
-        c.realm_roles_path = ["roles", ["nested"]]
-      end
-
-      published = Verikloak::Pundit.config
-
-      Verikloak::Pundit.configure do |c|
-        c.role_map[:admin] << :additional
-        c.realm_roles_path.last << "another"
-      end
-
-      expect(published.role_map[:admin]).to eq([:manage_all])
-      expect(published.realm_roles_path).to eq(["roles", ["nested"]])
-    ensure
-      Verikloak::Pundit.configure do |c|
-        c.role_map = {}
-        c.realm_roles_path = %w[realm_access roles]
-        c.permission_resource_clients = nil
-        c.expose_helper_method = true
-      end
+    Verikloak::Pundit.configure do |c|
+      c.role_map = { admin: [:manage_all] }
+      c.realm_roles_path = ["roles", ["nested"]]
     end
+
+    published = Verikloak::Pundit.config
+
+    Verikloak::Pundit.configure do |c|
+      c.role_map[:admin] << :additional
+      c.realm_roles_path.last << "another"
+    end
+
+    expect(published.role_map[:admin]).to eq([:manage_all])
+    expect(published.realm_roles_path).to eq(["roles", ["nested"]])
   end
 
   it "stringifies and de-duplicates permission_resource_clients" do
@@ -103,5 +79,17 @@ RSpec.describe Verikloak::Pundit::Configuration do
     cfg.permission_resource_clients = [:api, :api, "rails-api"]
     finalized = cfg.dup.finalize!
     expect(finalized.permission_resource_clients).to eq(%w[api rails-api])
+  end
+
+  it "resets configuration to defaults" do
+    Verikloak::Pundit.configure do |c|
+      c.resource_client = "custom"
+      c.role_map = { admin: :all }
+    end
+
+    Verikloak::Pundit.reset!
+
+    expect(Verikloak::Pundit.config.resource_client).to eq("rails-api")
+    expect(Verikloak::Pundit.config.role_map).to eq({})
   end
 end

--- a/verikloak-pundit.gemspec
+++ b/verikloak-pundit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'pundit', '~> 2.3'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.1.5', '< 1.0.0'
+  spec.add_dependency 'verikloak', '>= 0.2.0', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
This PR refactors the module structure and optimizes performance in verikloak-pundit by introducing a centralized `Delegations` module and improving permission lookup performance.

## Key Changes

### **Module Refactoring**
- **New `Delegations` module**: Centralized all delegation methods (`has_role?`, `in_group?`, `resource_role?`, `has_permission?`)
- **Deprecated `Helpers` and `Policy`**: Both now include `Delegations` with deprecation warnings
- **Reduced code duplication**: Single source of truth for delegation logic

### **Performance Improvements**
- **Set-based permission lookup**: Changed from `Array` to `Set` for O(1) permission checks
- **Enhanced caching**: Added proper memoization for `realm_roles`, `resource_roles`, and `permission_set`
- **Optimized configuration duplication**: Unified `dup_hash`, `dup_array`, `dup_string` into single `deep_dup` method

### **Configuration Enhancements**
- **Added `reset!` method**: Clean way to restore defaults (useful for test suites)
- **String constants**: Extracted JWT claim keys as constants (`CLAIM_SUB`, `CLAIM_EMAIL`, etc.)
- **Improved `ClaimUtils.normalize`**: Better handling of edge cases