### PR TITLE
Change railtie process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-01-01
+
+### Fixed
+- **ENV fallback preservation**: `Configuration#dup` now correctly preserves the `nil` state of `resource_client`, allowing ENV fallback to remain dynamic after duplication. Previously, duplicating a config would freeze the resolved ENV value.
+- **Non-hash resource_access entries**: `resource_roles_all_clients` now guards against malformed `resource_access` entries that are not hashes, preventing potential `NoMethodError`.
+
+### Changed
+- **role_map key normalization**: `role_map` keys are now automatically normalized to symbols when set. This allows users to configure with string keys (e.g., from YAML) while maintaining consistent symbol-based lookup in `RoleMapper`.
+- **pundit_user memoization**: `Controller#pundit_user` is now memoized with `@pundit_user ||=` to avoid creating multiple `UserContext` instances per request.
+
+---
+
 ## [0.2.4] - 2026-01-01
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    verikloak-pundit (0.2.4)
+    verikloak-pundit (0.3.0)
       pundit (~> 2.3)
       rack (>= 2.2, < 4.0)
       verikloak (>= 0.3.0, < 1.0.0)

--- a/lib/verikloak/pundit/controller.rb
+++ b/lib/verikloak/pundit/controller.rb
@@ -14,9 +14,10 @@ module Verikloak
       end
 
       # Pundit hook returning the UserContext built from Rack env claims.
+      # Memoized to avoid creating multiple instances per request.
       # @return [UserContext]
       def pundit_user
-        Verikloak::Pundit::UserContext.from_env(request.env)
+        @pundit_user ||= Verikloak::Pundit::UserContext.from_env(request.env)
       end
 
       # Access raw Verikloak claims from Rack env.

--- a/lib/verikloak/pundit/railtie.rb
+++ b/lib/verikloak/pundit/railtie.rb
@@ -16,7 +16,7 @@ module Verikloak
       # Synchronize configuration with verikloak-rails when available.
       # Runs after verikloak-rails configuration is applied.
       initializer 'verikloak_pundit.sync_configuration', after: 'verikloak.configure' do
-        sync_with_verikloak_rails if defined?(Verikloak::Rails)
+        Verikloak::Pundit::Railtie.sync_with_verikloak_rails if defined?(Verikloak::Rails)
       end
 
       class << self

--- a/lib/verikloak/pundit/version.rb
+++ b/lib/verikloak/pundit/version.rb
@@ -5,6 +5,6 @@ module Verikloak
     # Gem version for verikloak-pundit.
     #
     # @return [String]
-    VERSION = '0.2.4'
+    VERSION = '0.3.0'
   end
 end


### PR DESCRIPTION
### Fixed
- **ENV fallback preservation**: `Configuration#dup` now correctly preserves the `nil` state of `resource_client`, allowing ENV fallback to remain dynamic after duplication. Previously, duplicating a config would freeze the resolved ENV value.
- **Non-hash resource_access entries**: `resource_roles_all_clients` now guards against malformed `resource_access` entries that are not hashes, preventing potential `NoMethodError`.

### Changed
- **role_map key normalization**: `role_map` keys are now automatically normalized to symbols when set. This allows users to configure with string keys (e.g., from YAML) while maintaining consistent symbol-based lookup in `RoleMapper`.
- **pundit_user memoization**: `Controller#pundit_user` is now memoized with `@pundit_user ||=` to avoid creating multiple `UserContext` instances per request.