### PR TITLE
Update libs and logics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-02-15
+
+### Changed
+- **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.0, < 1.0.0`
+- Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`
+
+### Fixed
+- **ClaimUtils.normalize observability**: `rescue StandardError` now captures the exception and emits a `warn` when `$DEBUG` is enabled, improving debuggability of malformed claims
+
+---
+
 ## [0.3.0] - 2026-01-01
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,10 @@ gemspec
 group :development, :test do
   gem 'rack-test'
   gem 'rake'
-  gem 'rspec'
+  gem 'rspec', '~> 3.13'
   gem 'rubocop', require: false
   gem 'rubocop-rake', require: false
-  gem 'rubocop-rspec', require: false
+  gem 'rubocop-rspec', '~> 3.9', require: false
 end
 
 # Security auditing for dependencies in development/CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    verikloak-pundit (0.3.0)
+    verikloak-pundit (0.4.0)
       pundit (~> 2.3)
       rack (>= 2.2, < 4.0)
-      verikloak (>= 0.3.0, < 1.0.0)
+      verikloak (>= 0.4.0, < 1.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -25,25 +25,25 @@ GEM
     base64 (0.3.0)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
-    bundler-audit (0.9.2)
-      bundler (>= 1.2.0, < 3)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
       thor (~> 1.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     diff-lcs (1.6.2)
     docile (1.4.1)
     drb (2.2.3)
-    faraday (2.14.0)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    faraday-retry (2.3.2)
+    faraday-retry (2.4.0)
       faraday (~> 2.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    json (2.15.2)
+    json (2.18.1)
     jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
@@ -53,18 +53,18 @@ GEM
     net-http (0.6.0)
       uri
     parallel (1.27.0)
-    parser (3.3.10.0)
+    parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
-    prism (1.6.0)
+    prism (1.9.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
     racc (1.8.1)
-    rack (3.2.3)
+    rack (3.2.4)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
-    rake (13.3.0)
+    rake (13.3.1)
     regexp_parser (2.11.3)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
@@ -81,7 +81,7 @@ GEM
     rspec-support (3.13.6)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.81.6)
+    rubocop (1.84.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -89,18 +89,18 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.47.1, < 2.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.47.1)
+    rubocop-ast (1.49.0)
       parser (>= 3.3.7.2)
-      prism (~> 1.4)
+      prism (~> 1.7)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
-    rubocop-rspec (3.7.0)
+    rubocop-rspec (3.9.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
     simplecov (0.22.0)
@@ -109,17 +109,17 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    thor (1.4.0)
+    thor (1.5.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.0.4)
-    verikloak (0.3.0)
-      faraday (>= 2.0, < 3.0)
-      faraday-retry (>= 2.0, < 3.0)
-      json (~> 2.6)
+    verikloak (0.4.0)
+      faraday (>= 2.14.1, < 3.0)
+      faraday-retry (>= 2.4.0, < 3.0)
+      json (~> 2.18)
       jwt (>= 2.7, < 4.0)
 
 PLATFORMS
@@ -132,11 +132,11 @@ DEPENDENCIES
   bundler-audit
   rack-test
   rake
-  rspec
+  rspec (~> 3.13)
   rspec_junit_formatter
   rubocop
   rubocop-rake
-  rubocop-rspec
+  rubocop-rspec (~> 3.9)
   simplecov
   verikloak-pundit!
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ end
   token presented to verikloak-pundit typically originates from the BFF
   (e.g. via the `x-verikloak-user` header). Make sure your Rack stack stores the
   decoded claims under the same `env_claims_key` (default: `"verikloak.user"`,
-  which works out of the box with `verikloak-bff >= 0.3`). If the BFF issues
+  which works out of the box with `verikloak-bff >= 0.4.0`). If the BFF issues
   tokens for multiple downstream services, set `permission_resource_clients` to
   the limited list of clients whose roles should affect Rails-side authorization
   to avoid accidentally inheriting permissions meant for other services.

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -34,13 +34,11 @@ RUN bundle install
 # App source
 COPY . .
 
-# Remove build dependencies to slim the image
-RUN apk del .build-deps
-
 # Run as non-root for safety in CI/dev, and match host UID/GID for bind-mount write access
 ARG UID=1000
 ARG GID=1000
 RUN addgroup -S -g $GID app \
     && adduser -S -u $UID -G app app \
-    && chown -R app:app /app
+    && chown -R app:app /app \
+    && chown -R app:app /usr/local/bundle
 USER app

--- a/lib/verikloak/pundit/claim_utils.rb
+++ b/lib/verikloak/pundit/claim_utils.rb
@@ -20,7 +20,8 @@ module Verikloak
         end
 
         {}
-      rescue StandardError
+      rescue StandardError => e
+        warn "[Verikloak::Pundit] ClaimUtils.normalize failed: #{e.class}: #{e.message}" if $DEBUG
         {}
       end
     end

--- a/lib/verikloak/pundit/version.rb
+++ b/lib/verikloak/pundit/version.rb
@@ -5,6 +5,6 @@ module Verikloak
     # Gem version for verikloak-pundit.
     #
     # @return [String]
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end

--- a/verikloak-pundit.gemspec
+++ b/verikloak-pundit.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Runtime dependencies
   spec.add_dependency 'pundit', '~> 2.3'
   spec.add_dependency 'rack', '>= 2.2', '< 4.0'
-  spec.add_dependency 'verikloak', '>= 0.3.0', '< 1.0.0'
+  spec.add_dependency 'verikloak', '>= 0.4.0', '< 1.0.0'
 
   # Metadata for RubyGems
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
### Changed
- **BREAKING**: Minimum `verikloak` dependency raised to `>= 0.4.0, < 1.0.0`
- Dev dependency `rspec` pinned to `~> 3.13`, `rubocop-rspec` pinned to `~> 3.9`

### Fixed
- **ClaimUtils.normalize observability**: `rescue StandardError` now captures the exception and emits a `warn` when `$DEBUG` is enabled, improving debuggability of malformed claims